### PR TITLE
Added basic middleware capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Your state model does not have to be named "State" or have any specific methods 
 
 
 ### 3. Creating a Root Reducer
-You can think of root reducer as the rust-redux substitute for combineReducers in reduxjs. Our root reducer just needs to return our State model where each property in our model is set to the return value of its individual reducer (We'll talk more about individual state reducers later on). The root reducer must be of type: `fn(&T, U) -> T`
+You can think of root reducer as the rust-redux substitute for combineReducers in reduxjs. Our root reducer just needs to return our State model where each property in our model is set to the return value of its individual reducer (We'll talk more about individual state reducers later on). The root reducer must be of type: `fn(&T, &U) -> T`
 ```
-fn root_reducer(state: &State, action: Action) -> State {
+fn root_reducer(state: &State, action: &Action) -> State {
     State {
-        todos: todo_reducer(&state.todos, &action),
-        visibility_filter: visibility_reducer(&state.visibility_filter,&action),
+        todos: todo_reducer(&state.todos, action),
+        visibility_filter: visibility_reducer(&state.visibility_filter, action),
     }
 }
 ```
@@ -147,3 +147,21 @@ fn main(){
     let myCurrentState = store.get_state();
 }
 ```
+
+### Adding Middleware
+The current implementation of middleware allows you to pass a function to the store that will be run
+each time an action is dispatched with the updated state and the action that was dispatched.
+Middleware function must be of type: `fn(&T, &U)`.
+```
+fn simple_logger(state: &State, action: &Action){
+  println!("Dispatched action {:?}. To-do list now contains: {:?}", action, state.todos);
+}
+
+fn main(){
+  let mut store = Store::create_store(reducer, State::with_defaults());
+  store.apply_middleware(simple_logger);
+}
+```
+### Additional Examples
+For more in depth examples that cover all of the above topics, take a look at the full-length todo_list
+example in `examples/todo_list`.

--- a/examples/todo_list/src/main.rs
+++ b/examples/todo_list/src/main.rs
@@ -139,9 +139,15 @@ fn render(state: &State) {
     print_instructions();
 }
 
+fn logger(state: &State, action: Action){
+    //write to separate file.
+    println!("{:?}", state.todos);
+}
+
 fn main() {
     let mut store = Store::create_store(reducer, State::with_defaults());
     store.subscribe(render);
+    store.apply_middleware(logger);
 
     print_instructions();
     loop {

--- a/examples/todo_list/src/main.rs
+++ b/examples/todo_list/src/main.rs
@@ -142,7 +142,6 @@ fn render(state: &State) {
     print_instructions();
 }
 
-//logger middleware that will write the state and action that updated it to a new file.
 #[allow(unused_must_use)]
 fn logger(state: &State, action: &Action){
 

--- a/examples/todo_list/src/main.rs
+++ b/examples/todo_list/src/main.rs
@@ -5,6 +5,8 @@ use rust_redux::{ Store };
 use Action::*;
 use TodoAction::*;
 use VisibilityFilter::*;
+use std::fs::File;
+use std::io::prelude::*;
 
 #[derive(Clone, Debug)]
 pub struct State {
@@ -60,11 +62,11 @@ pub enum VisibilityFilter {
     ShowCompleted,
 }
 
-fn reducer(state: &State, action: Action) -> State {
+fn reducer(state: &State, action: &Action) -> State {
     // Always return a new state
     State {
-        todos: todo_reducer(&state.todos, &action),
-        visibility_filter: visibility_reducer(&state.visibility_filter, &action),
+        todos: todo_reducer(&state.todos, action),
+        visibility_filter: visibility_reducer(&state.visibility_filter, action),
     }
 }
 
@@ -139,9 +141,10 @@ fn render(state: &State) {
     print_instructions();
 }
 
-fn logger(state: &State, action: Action){
-    //write to separate file.
-    println!("{:?}", state.todos);
+//logger middleware that will write the state and action that updated it to a new file.
+fn logger(state: &State, action: &Action){
+    let mut logger_file = File::create("logger.txt")?;
+    logger_file.write("MiddleWAREEEE.")?;
 }
 
 fn main() {

--- a/examples/todo_list/src/main.rs
+++ b/examples/todo_list/src/main.rs
@@ -5,7 +5,8 @@ use rust_redux::{ Store };
 use Action::*;
 use TodoAction::*;
 use VisibilityFilter::*;
-use std::fs::File;
+
+use std::fs::OpenOptions;
 use std::io::prelude::*;
 
 #[derive(Clone, Debug)]
@@ -142,9 +143,26 @@ fn render(state: &State) {
 }
 
 //logger middleware that will write the state and action that updated it to a new file.
+#[allow(unused_must_use)]
 fn logger(state: &State, action: &Action){
-    let mut logger_file = File::create("logger.txt")?;
-    logger_file.write("MiddleWAREEEE.")?;
+
+    let mut log_file = OpenOptions::new()
+                            .write(true)
+                            .create(true)
+                            .append(true)
+                            .open("log.txt")
+                            .expect("Failed to open log file.");
+    log_file.write(b"----------------------------------------------------\n");
+    log_file.write(format!("ACTION DISPATCHED: {:?}\n", action).as_bytes());
+    log_file.write(b"***************************************************\n");
+    log_file.write(b"UPDATED STATE\n");
+    log_file.write(b"***************************************************\n");
+    log_file.write(format!("Visibility: {:?}\n", state.visibility_filter).as_bytes());
+    log_file.write(b"Todo List: \n");
+    for todo in &state.todos{
+        log_file.write(format!("{:?}\n", todo).as_bytes());
+    }
+    log_file.write(b"----------------------------------------------------\n\n\n");
 }
 
 fn main() {
@@ -156,8 +174,8 @@ fn main() {
     loop {
         let mut command = String::new();
         io::stdin()
-            .read_line(&mut command)
-            .expect("failed to read line");
+        .read_line(&mut command)
+        .expect("failed to read line");
         let command_parts: Vec<&str> = command.split_whitespace().collect();
 
         match command_parts.len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,13 @@ use std::clone::Clone;
 pub struct Store<T: Clone, U> {
     state: T,
     listeners: Vec<fn(&T)>,
-    middlewares: Vec<fn(&T, U)>,
-    reducer: fn(&T,U) -> T,
+    middlewares: Vec<fn(&T, &U)>,
+    reducer: fn(&T,&U) -> T,
 }
 
 #[allow(dead_code)]
 impl<T: Clone, U> Store<T, U> {
-    pub fn create_store(reducer: fn(&T, U) -> T, initial_state: T) -> Store<T, U> {
+    pub fn create_store(reducer: fn(&T, &U) -> T, initial_state: T) -> Store<T, U> {
         Store {
             state: initial_state,
             listeners: Vec::new(),
@@ -23,7 +23,7 @@ impl<T: Clone, U> Store<T, U> {
         self.listeners.push(listener);
     }
 
-    pub fn apply_middleware(&mut self, middleware: fn(&T, U)) {
+    pub fn apply_middleware(&mut self, middleware: fn(&T, &U)) {
         self.middlewares.push(middleware);
     }
 
@@ -32,10 +32,12 @@ impl<T: Clone, U> Store<T, U> {
     }
 
     pub fn dispatch(&mut self, action:U) {
-        self.state = (self.reducer)(&self.state, action.clone());
+        self.state = (self.reducer)(&self.state, &action );
+
         for middleware in &self.middlewares{
-            middleware(&self.state, action.clone());
+            middleware(&self.state, &action);
         }
+
         for listener in &self.listeners {
             listener(&self.state)
         }


### PR DESCRIPTION
### What did I do?
* Added apply_middleware() method to Store that accepts fn(&T, &U). It is essentially the same as subscribing to the store except this also allows you to get the specific action that was dispatched.
* Added a logger middleware in the todo_list example.
* I also changed the definition of reducer from fn(&T, U) -> T to fn(&T, &U) -> T. I had to use the action in more than one place inside the dispatch function. If you know a better way to do this let me know. I am still pretty new to rust so any helpful criticism is very much appreciated.
* Updated README.md with updated information on middleware and new reducer definition.

Notes for the future:
My goal for the next few days/week is to change the Store to support interior mutability. Essentially, the struct Store would become immutable, but these Store methods would edit data inside the Store that is mutable. I'm a little unfamiliar with this kind of stuff, but I know rust has good support for it. What interior mutability would allow is to do things like chaining store methods and writing a middleware platform that could manipulate the store; all without  handing out a mutable reference of the store to the user.