### PR TITLE
Added chaining functionality to subscribe method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,16 @@ fn update_with_new_state(state: &State) {
 	let visibility = &state.visibility_filter;
 	println!("Visibility filter updated to:  {:?}", visibility);
 }
+
+fn simple_subscribe(state: &State) {
+  println!("nice dispatch!");
+}
+
 fn main(){
 	let mut store = Store::create_store(reducer, State::with_defaults());
-	store.subscribe(update_with_new_state);
+  //subscribe methods can be chained together
+	store.subscribe(update_with_new_state)
+       .subscribe(simple_subscribe);
 }
 ```
 ### Getting State

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,9 @@ impl<T: Clone, U> Store<T, U> {
             reducer: reducer,
         }
     }
-    pub fn subscribe(&mut self, listener: fn(&T)) {
+    pub fn subscribe(&mut self, listener: fn(&T)) -> &mut Store<T, U> {
         self.listeners.push(listener);
+        self
     }
 
     pub fn get_state(&self) -> &T {


### PR DESCRIPTION
* This pr is completely separate from the middleware pr. I want to continue a pattern here where each method that adds to the store like subscribe and apply_middleware return a reference to the store so the following is allowed (apply_middleware isn't implemented in this pr. This is just an example)

```
store.subscribe(render).apply_middleware(logger)
```
* In this pr I just changed the readme and the definition/implementation of the subscribe method to allow for method chaining.