### PR TITLE
Converted Store implementation to use Interior Mutability and added Field Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,3 @@
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
 Cargo.lock
 target
-Cargo.lock
-target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust_redux"
 version = "0.1.0"
-authors = ["Fredrik Andersson <fredrik.andersson@widespace.com>"]
+authors = ["Fredrik Andersson <fredrik.andersson@widespace.com>, Clayton Marshall <marsha88@purdue.edu>"]
 repository = "https://github.com/fanderzon/rust-redux.git"
 license = "MIT"
 readme = "README.md"

--- a/examples/todo_list/Cargo.toml
+++ b/examples/todo_list/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "todo_list"
 version = "0.1.0"
-authors = ["Fredrik Andersson <fredrik.andersson@widespace.com>"]
+authors = ["Fredrik Andersson <fredrik.andersson@widespace.com>, Clayton Marshall <marsha88@purdue.edu>"]
 
 [dependencies]
 rust_redux = { path = "../../"}

--- a/examples/todo_list/src/main.rs
+++ b/examples/todo_list/src/main.rs
@@ -143,7 +143,7 @@ fn render(state: &State) {
 }
 
 #[allow(unused_must_use)]
-fn logger(state: &mut State, action: &Action) {
+fn logger(state: &mut Store, action: &Action) {
     let mut log_file = OpenOptions::new()
     .write(true)
     .create(true)
@@ -163,15 +163,13 @@ fn logger(state: &mut State, action: &Action) {
     log_file.write(b"----------------------------------------------------\n\n\n");
 }
 
-fn mutate_state(state: &mut State, action: &Action) {
+fn mutate_state(store:&mut Store, action:&Action) {
     state.visibility_filter = ShowAll;
 }
 
 fn main() {
     let mut store = Store::create_store(reducer, State::with_defaults());
-    store.subscribe(render)
-    .apply_middleware(logger)
-    .apply_middleware(mutate_state);
+    store.subscribe(render);
 
     print_instructions();
     loop {

--- a/examples/todo_list/src/main.rs
+++ b/examples/todo_list/src/main.rs
@@ -9,10 +9,6 @@ use VisibilityFilter::*;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
 
-trait UpdateFields <T> {
-    fn update_fields<T>(&self) -> T;
-}
-
 #[derive(Clone, Debug)]
 pub struct State {
     pub todos: Vec<Todo>,

--- a/examples/todo_list/src/main.rs
+++ b/examples/todo_list/src/main.rs
@@ -1,7 +1,7 @@
 extern crate rust_redux;
 
 use std::io;
-use rust_redux::{ Store, Update_Fields };
+use rust_redux::Store;
 use Action::*;
 use TodoAction::*;
 use VisibilityFilter::*;
@@ -22,13 +22,6 @@ impl State {
             todos: Vec::new(),
             visibility_filter: VisibilityFilter::ShowAll,
         }
-    }
-}
-
-impl Update_Fields <State> for State {
-    fn update_fields(&mut self, updates: State){
-        self.todos = updates.todos;
-        self.visibility_filter = updates.visibility_filter;
     }
 }
 
@@ -71,7 +64,7 @@ pub enum VisibilityFilter {
     ShowCompleted,
 }
 
-fn reducer(state: Ref<State>, action: &Action) -> State {
+fn reducer(state: &State, action: &Action) -> State {
     // Always return a new state
     State {
         todos: todo_reducer(&state.todos, action),
@@ -133,7 +126,7 @@ fn invalid_command(command: &str) {
     println!("Invalid command: {}", command);
 }
 
-fn render(state: Ref<State>) {
+fn render(state: &State) {
     let visibility = &state.visibility_filter;
     println!("\n\nTodo List:\n-------------------");
     for i in 0..state.todos.len() {
@@ -173,7 +166,7 @@ fn logger(state: Ref<State>, action: &Action) {
 
 
 fn main() {
-    let store = Store::create_store(reducer, State::with_defaults());
+    let mut store = Store::create_store(reducer, State::with_defaults());
     store.subscribe(render);
 
     print_instructions();

--- a/examples/todo_list/src/main.rs
+++ b/examples/todo_list/src/main.rs
@@ -1,13 +1,14 @@
 extern crate rust_redux;
 
 use std::io;
-use rust_redux::{ Store };
+use rust_redux::{ Store, Update_Fields };
 use Action::*;
 use TodoAction::*;
 use VisibilityFilter::*;
 
 use std::fs::OpenOptions;
 use std::io::prelude::*;
+use std::cell::Ref;
 
 #[derive(Clone, Debug)]
 pub struct State {
@@ -24,9 +25,10 @@ impl State {
     }
 }
 
-impl UpdateFields <T> for T {
-    fn update_fields <T>(&self) -> T {
-
+impl Update_Fields <State> for State {
+    fn update_fields(&mut self, updates: State){
+        self.todos = updates.todos;
+        self.visibility_filter = updates.visibility_filter;
     }
 }
 
@@ -69,7 +71,7 @@ pub enum VisibilityFilter {
     ShowCompleted,
 }
 
-fn reducer(state: &State, action: &Action) -> State {
+fn reducer(state: Ref<State>, action: &Action) -> State {
     // Always return a new state
     State {
         todos: todo_reducer(&state.todos, action),
@@ -131,7 +133,7 @@ fn invalid_command(command: &str) {
     println!("Invalid command: {}", command);
 }
 
-fn render(state: &State) {
+fn render(state: Ref<State>) {
     let visibility = &state.visibility_filter;
     println!("\n\nTodo List:\n-------------------");
     for i in 0..state.todos.len() {
@@ -149,7 +151,7 @@ fn render(state: &State) {
 }
 
 #[allow(unused_must_use)]
-fn logger(state: &mut Store, action: &Action) {
+fn logger(state: Ref<State>, action: &Action) {
     let mut log_file = OpenOptions::new()
     .write(true)
     .create(true)
@@ -169,12 +171,9 @@ fn logger(state: &mut Store, action: &Action) {
     log_file.write(b"----------------------------------------------------\n\n\n");
 }
 
-fn mutate_state(store:&mut Store, action:&Action) {
-    state.visibility_filter = ShowAll;
-}
 
 fn main() {
-    let mut store = Store::create_store(reducer, State::with_defaults());
+    let store = Store::create_store(reducer, State::with_defaults());
     store.subscribe(render);
 
     print_instructions();

--- a/examples/todo_list/src/main.rs
+++ b/examples/todo_list/src/main.rs
@@ -9,6 +9,10 @@ use VisibilityFilter::*;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
 
+trait UpdateFields <T> {
+    fn update_fields<T>(&self) -> T;
+}
+
 #[derive(Clone, Debug)]
 pub struct State {
     pub todos: Vec<Todo>,
@@ -21,6 +25,12 @@ impl State {
             todos: Vec::new(),
             visibility_filter: VisibilityFilter::ShowAll,
         }
+    }
+}
+
+impl UpdateFields <T> for T {
+    fn update_fields <T>(&self) -> T {
+
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,12 +31,13 @@ impl<T: Clone, U> Store<T, U> {
         self
     }
 
-    pub fn get_state(&self) -> Ref<T> {
-        self.state.borrow()
+    pub fn get_state(&self) -> T {
+        *self.state.borrow()
     }
 
     pub fn dispatch(&self, action:U) {
-        (self.reducer)(self.state.borrow_mut(), &action);
+        //force the State struct to have an updateFields method
+        self.state.borrow_mut().update_fields((self.reducer)(self.state.borrow_mut(), &action));
 
         for middleware in self.middlewares.borrow().iter(){
             middleware(self, &action);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,8 @@ impl<T: Clone + Update_Fields<T>, U> Store<T, U> {
     }
 
     pub fn dispatch(&self, action:U) {
-        self.state.borrow().update_fields((self.reducer)(self.state.borrow(), &action));
+        let stateUpdates:T = (self.reducer)(self.state.borrow(), &action);
+        self.state.borrow_mut().update_fields(stateUpdates);
 
         for middleware in self.middlewares.borrow().iter(){
             middleware(self, &action);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,16 +4,18 @@ use std::clone::Clone;
 pub struct Store<T: Clone, U> {
     state: T,
     listeners: Vec<fn(&T)>,
-    reducer: fn(&T,U) -> T,
+    middlewares: Vec<fn(&mut T, &U)>,
+    reducer: fn(&T,&U) -> T,
 }
 
 #[allow(dead_code)]
 impl<T: Clone, U> Store<T, U> {
-    pub fn create_store(reducer: fn(&T, U) -> T, initial_state: T) -> Store<T, U> {
+    pub fn create_store(reducer: fn(&T, &U) -> T, initial_state: T) -> Store<T, U> {
         Store {
             state: initial_state,
             listeners: Vec::new(),
             reducer: reducer,
+            middlewares: Vec::new()
         }
     }
     pub fn subscribe(&mut self, listener: fn(&T)) -> &mut Store<T, U> {
@@ -21,12 +23,22 @@ impl<T: Clone, U> Store<T, U> {
         self
     }
 
+    pub fn apply_middleware(&mut self, middleware: fn(&mut T, &U)) -> &mut Store<T, U> {
+        self.middlewares.push(middleware);
+        self
+    }
+
     pub fn get_state(&self) -> &T {
         &self.state
     }
 
-    pub fn dispatch(&mut self, action: U) {
-        self.state = (self.reducer)(&self.state, action);
+    pub fn dispatch(&mut self, action:U) {
+        self.state = (self.reducer)(&self.state, &action);
+
+        for middlewares in &self.middlewares{
+            middlewares(&mut self.state, &action);
+        }
+
         for listener in &self.listeners {
             listener(&self.state)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use std::cell::RefMut;
 
 // allows the Store's state to be updated without reducers directly mutating the Store.
 pub trait Update_Fields <T> {
-    fn update_fields(&self, T);
+    fn update_fields(&mut self, T);
 }
 
 #[allow(dead_code)]
@@ -13,12 +13,12 @@ pub struct Store<T: Clone + Update_Fields<T>, U> {
     state: RefCell<T>,
     listeners: RefCell<Vec<fn(Ref<T>)>>,
     middlewares: RefCell<Vec<fn(&Store<T,U>, &U)>>,
-    reducer: fn(RefMut<T>,&U) -> T,
+    reducer: fn(Ref<T>,&U) -> T,
 }
 
 #[allow(dead_code)]
 impl<T: Clone + Update_Fields<T>, U> Store<T, U> {
-    pub fn create_store(reducer: fn(RefMut<T>, &U) -> T, initial_state: T) -> Store<T, U> {
+    pub fn create_store(reducer: fn(Ref<T>, &U) -> T, initial_state: T) -> Store<T, U> {
         Store {
             state: RefCell::new(initial_state),
             listeners: RefCell::new(Vec::new()),
@@ -41,7 +41,7 @@ impl<T: Clone + Update_Fields<T>, U> Store<T, U> {
     }
 
     pub fn dispatch(&self, action:U) {
-        self.state.borrow_mut().update_fields((self.reducer)(self.state.borrow_mut(), &action));
+        self.state.borrow().update_fields((self.reducer)(self.state.borrow(), &action));
 
         for middleware in self.middlewares.borrow().iter(){
             middleware(self, &action);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,19 @@
 use std::clone::Clone;
 use std::cell::RefCell;
+use std::cell::Ref;
+use std::cell::RefMut;
 
 #[allow(dead_code)]
 pub struct Store<T: Clone, U> {
     state: RefCell<T>,
-    listeners: RefCell<Vec<fn(&T)>>,
-    middlewares: RefCell<Vec<fn(&Store<T, U>, &U)>>,
-    reducer: fn(&T,&U) -> T,
+    listeners: RefCell<Vec<fn(Ref<T>)>>,
+    middlewares: RefCell<Vec<fn(&Store<T,U>, &U)>>,
+    reducer: fn(RefMut<T>,&U),
 }
 
 #[allow(dead_code)]
 impl<T: Clone, U> Store<T, U> {
-    pub fn create_store(reducer: fn(&T, &U) -> T, initial_state: T) -> Store<T, U> {
+    pub fn create_store(reducer: fn(RefMut<T>, &U), initial_state: T) -> Store<T, U> {
         Store {
             state: RefCell::new(initial_state),
             listeners: RefCell::new(Vec::new()),
@@ -19,24 +21,29 @@ impl<T: Clone, U> Store<T, U> {
             reducer: reducer
         }
     }
-    pub fn subscribe(&self, listener: fn(&T)) -> &Store<T, U> {
+    pub fn subscribe(&self, listener: fn(Ref<T>)) -> &Store<T, U> {
         self.listeners.borrow_mut().push(listener);
         self
     }
 
-    pub fn get_state(&self) -> &T {
+    pub fn apply_middleware(&self, middleware:fn(&Store<T,U>, &U)) -> &Store<T,U> {
+        self.middlewares.borrow_mut().push(middleware);
+        self
+    }
+
+    pub fn get_state(&self) -> Ref<T> {
         self.state.borrow()
     }
 
     pub fn dispatch(&self, action:U) {
-        self.state = (self.reducer)(&self.state.borrow(), &action);
+        (self.reducer)(self.state.borrow_mut(), &action);
 
         for middleware in self.middlewares.borrow().iter(){
-            middleware(&self.state.borrow(), &action);
+            middleware(self, &action);
         }
 
         for listener in self.listeners.borrow().iter() {
-            listener(&self.state.borrow())
+            listener(self.state.borrow())
         }
     }
 }


### PR DESCRIPTION
* Before building better middleware we needed to change the store implementation up to use interior mutability for the state of the Store to allow passing of multiple store references. This PR implements those changes. Look over it and let me know if you think it could be improved.

* Due to the change in Store implementation the State struct that the user adds needs to implement a trait I made called Update_Fields. This requires a single function implementation which is update_fields() and it is responsible for updating the fields of a mutable State reference given another State struct. This is used to replace the line inside of the dispatch method that updates the Store's state. 

* I also added my name to the authors list inside of the .toml if that is ok with you.

* The middleware isn't in working condition yet, but these changes needed to be made before continuing work on that.